### PR TITLE
roommates: enable indexing in Mongo DB

### DIFF
--- a/api/staging.js
+++ b/api/staging.js
@@ -21,9 +21,11 @@ const USER_DB = 'users';
 const GROUP_DB = 'groups';
 
 // Create the db connection
-MongoClient.connect(url, { useNewUrlParser: true }, function(err, db) {  
+MongoClient.connect(url, { useNewUrlParser: true }, function(err, db) {
     assert.equal(null, err);
     mongodb = db.db();
+    mongodb.collection(USER_DB).ensureIndex('id');
+    mongodb.collection(GROUP_DB).ensureIndex('id');
 });
 
 function handleUnexpectedError(err, res) {


### PR DESCRIPTION
MongoDB by default indexes on the hidden `_id` field. We want it to also index on our own `id` field for fast lookup and operations.
