### PR TITLE
roommates: use Alpine Linux in production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM mhart/alpine-node:8
+WORKDIR /app
+COPY . .
+
+RUN ["npm", "install", "--production"]
+RUN ["npm", "run", "build"]
+CMD ["npm", "run", "start"]

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
         "dev-build": "webpack --mode development --progress --watch --display-modules --config dashboard/webpack.dev.js",
         "dev-serve-api": "nodemon --watch index.js --watch api index.js",
         "dev": "concurrently --kill-others 'npm:dev-build' 'npm:dev-serve-api'",
-        "build": "webpack --mode production --progress --config dashboard/webpack.prod.js",
-        "start": "npm run build && NODE_ENV=production node index.js"
+        "build": "webpack --mode production --config dashboard/webpack.prod.js",
+        "start": "NODE_ENV=production node index.js"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
Uses less memory and also sets up build process as part of deploy.