### PR TITLE
roommates: fit logout button container to content

### DIFF
--- a/dashboard/src/index.vue
+++ b/dashboard/src/index.vue
@@ -63,7 +63,7 @@
                             getTitle($route.params.groupId)
                         }}</mdc-toolbar-title>
                     </mdc-toolbar-section>
-                    <mdc-toolbar-section align-end>
+                    <mdc-toolbar-section align-end style="flex-grow: 0; min-width: auto;">
                         <mdc-toolbar-icon @click="logout" icon="exit_to_app"></mdc-toolbar-icon>
                     </mdc-toolbar-section>
                 </mdc-toolbar-row>


### PR DESCRIPTION
On mobile, the logout button sometimes overlaps the text incorrectly. Because the container takes up 50%. This fixes it by forcing the container to fit the content.

Relates to #85 