### PR TITLE
roommates: fix weird reloading when group updated

### DIFF
--- a/dashboard/src/index.vue
+++ b/dashboard/src/index.vue
@@ -136,7 +136,9 @@ export default {
             if (response.config.method !== 'get') {
                 /* This is primarily for updating the list of groups to
                  * represent the last_modified */
-                this.loadUserAndGroups();
+                setTimeout(() => {
+                    this.loadUserAndGroups();
+                }, 0);
             }
             return response;
         });


### PR DESCRIPTION
Making an API request while handling one leads to weird behaviours with the reload indicator. This will launch the new `loadUserAndGroups` call in a separate context, so it will let the current call handling finish before creating a new one. 